### PR TITLE
Ability to pass fetch implementation

### DIFF
--- a/src/GamejoltGameApi.ts
+++ b/src/GamejoltGameApi.ts
@@ -1,3 +1,4 @@
+import { Config } from ".";
 import { GamejoltDataStorageApi } from "./resources/GameJoltDataStorageApi";
 import { GamejoltScoresApi } from "./resources/GameJoltScoresApi";
 import { GamejoltTrophiesApi } from "./resources/GameJoltTrophiesApi";
@@ -7,7 +8,7 @@ export class GamejoltGameApi
     public readonly token?: string;
     public readonly username?: string;
 
-    constructor(private_key: string, game_id: number)
+    constructor(private_key: string, game_id: number, public readonly config: Config)
     {
         const query_string = window.location.search;
         const url_params = new URLSearchParams(query_string);
@@ -15,9 +16,9 @@ export class GamejoltGameApi
         this.token = url_params.get("gjapi_token");
         this.username = url_params.get("gjapi_username");
 
-        this.trophies = new GamejoltTrophiesApi(private_key, game_id);
-        this.scores = new GamejoltScoresApi(private_key, game_id);
-        this.dataStorage = new GamejoltDataStorageApi(private_key, game_id);
+        this.trophies = new GamejoltTrophiesApi(private_key, game_id, config);
+        this.scores = new GamejoltScoresApi(private_key, game_id, config);
+        this.dataStorage = new GamejoltDataStorageApi(private_key, game_id, config);
     }
 
     /**

--- a/src/GamejoltGameApi.ts
+++ b/src/GamejoltGameApi.ts
@@ -10,11 +10,14 @@ export class GamejoltGameApi
 
     constructor(private_key: string, game_id: number, public readonly config: Config)
     {
-        const query_string = window.location.search;
-        const url_params = new URLSearchParams(query_string);
+        if (typeof window !== "undefined")
+        {
+            const query_string = window.location.search;
+            const url_params = new URLSearchParams(query_string);
 
-        this.token = url_params.get("gjapi_token");
-        this.username = url_params.get("gjapi_username");
+            this.token = url_params.get("gjapi_token");
+            this.username = url_params.get("gjapi_username");
+        }
 
         this.trophies = new GamejoltTrophiesApi(private_key, game_id, config);
         this.scores = new GamejoltScoresApi(private_key, game_id, config);

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,12 +5,16 @@ export * from "./resources/GameJoltDataStorageApi"
 export * from "./resources/GameJoltScoresApi"
 export * from "./resources/GameJoltTrophiesApi"
 
+export interface Config {
+    readonly fetch?: typeof window.fetch;
+}
+
 /**
  * Create an instance of {@link GamejoltGameApi}
  * @param private_key the unique secret private game key.
  * @param game_id the unique game id.
  * @returns 
  */
-export function create(private_key: string, game_id: number) : GamejoltGameApi {
-    return new GamejoltGameApi(private_key, game_id, );
+export function create(private_key: string, game_id: number, config?: Partial<Config>) : GamejoltGameApi {
+    return new GamejoltGameApi(private_key, game_id, { fetch: config?.fetch ?? fetch });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,17 @@ export * from "./resources/GameJoltScoresApi"
 export * from "./resources/GameJoltTrophiesApi"
 
 export interface Config {
-    readonly fetch?: typeof window.fetch;
+    readonly fetch: typeof window.fetch;
+}
+
+function parse_config(config?: Partial<Config>): Config {
+    let fetch = config?.fetch;
+
+    if (!fetch && typeof window !== "undefined") {
+        fetch = window.fetch;
+    }
+    
+    return { fetch };
 }
 
 /**
@@ -16,5 +26,5 @@ export interface Config {
  * @returns 
  */
 export function create(private_key: string, game_id: number, config?: Partial<Config>) : GamejoltGameApi {
-    return new GamejoltGameApi(private_key, game_id, { fetch: config?.fetch ?? fetch });
+    return new GamejoltGameApi(private_key, game_id, parse_config(config));
 }

--- a/src/resources/GamejoltBaseApi.ts
+++ b/src/resources/GamejoltBaseApi.ts
@@ -1,4 +1,5 @@
 import CryptoJS from "crypto-js";
+import { Config } from "..";
 
 export interface GamejoltResponse 
 {
@@ -43,7 +44,7 @@ export abstract class GamejoltBaseApi
      */
     protected readonly m_gjApiUserName: string;
 
-    constructor(private readonly m_privateKey: string, private readonly m_gameId: number)
+    constructor(private readonly m_privateKey: string, private readonly m_gameId: number, private readonly config: Config)
     {
         const query_string = window.location.search;
         const url_params = new URLSearchParams(query_string);
@@ -98,7 +99,7 @@ export abstract class GamejoltBaseApi
         const signature = CryptoJS.MD5(`${url}${this.m_privateKey}`).toString();
         url += `&signature=${signature}`;
 
-        const response = await fetch(url);
+        const response = await this.config.fetch(url);
         const response_json = await response.json();
 
         const result = response_json.response as GamejoltResponse;


### PR DESCRIPTION
Add the ability to pass `fetch` implementation.

## Context

I'm trying to use this library from a Sveltekit application and Svelte has it's own `fetch` implementation that I need to pass in. It's the exact same as the one available in the browser, but with added benefits to Svelte apps.

Secondly, by being able to pass the `fetch` implementation (and checking for `window`) the library will be use-able from all NodeJS apps. `fetch` is not natively built into NodeJS. There are implementations of it.

It makes sense to be able to pass the `fetch` implementation. What do you think?